### PR TITLE
This is a small fix that solves a situation where a user is enrolled …

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -52,6 +52,23 @@
             ]
           },
           "configurations": {
+            "local": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.local.ts"
+                }
+              ],
+              "optimization": false,
+              "outputHashing": "all",
+              "sourceMap": false,
+              "extractCss": true,
+              "namedChunks": false,
+              "aot": true,
+              "extractLicenses": true,
+              "vendorChunk": false,
+              "buildOptimizer": true
+            },
             "trial": {
               "fileReplacements": [
                 {

--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -130,7 +130,9 @@ export class AuthService {
       programs: data.Timelines.map(
         timeline => {
           // make sure 'Program.config.theme_color' exist
-          if (!this.utils.has(timeline, 'Program.config.theme_color')) {
+          if (!this.utils.has(timeline, 'Program.config')) {
+            timeline.Program.config = {theme_color: 'var(--ion-color-primary)'};
+          } else if (!this.utils.has(timeline, 'Program.config.theme_color')) {
             timeline.Program.config.theme_color = 'var(--ion-color-primary)';
           }
           return {

--- a/src/app/switcher/switcher-program/switcher-program.component.html
+++ b/src/app/switcher/switcher-program/switcher-program.component.html
@@ -16,6 +16,7 @@
             <clickable-item color="light" [lines]="'none'" [backgroundColor]="program.program.config.theme_color" [isSwitcherCard]="true">
               <ion-label class="subtitle-1">
                 {{ program.program.name }}
+                <ion-label *ngIf='program.experience.config.show_timeline_title'><em>{{ program.timeline.title }}</em></ion-label>
                 <!-- <ion-progress-bar *ngIf="program.progress !== undefined" [value]="program.progress"></ion-progress-bar> -->
               </ion-label>
               <!-- <ion-badge *ngIf="program.todoItems !== undefined" slot="end">{{ program.todoItems }}</ion-badge> -->

--- a/src/app/switcher/switcher.service.ts
+++ b/src/app/switcher/switcher.service.ts
@@ -52,6 +52,7 @@ export interface Project {
 
 export interface Timeline {
   id: number;
+  title: string;
 }
 
 export interface Experience {
@@ -84,6 +85,9 @@ export class SwitcherService {
     const cdn = 'https://cdn.filestackcontent.com/resize=fit:crop,width:';
     let imagewidth = 600;
     programs.forEach(program => {
+      if (program.experience.config && typeof program.experience.config === 'string') {
+        program.experience.config = JSON.parse(program.experience.config);
+      }
       if (program.project.lead_image) {
         const imageId = program.project.lead_image.split('/').pop();
         if (!this.utils.isMobile()) {

--- a/src/environments/environment.local.ts
+++ b/src/environments/environment.local.ts
@@ -1,0 +1,50 @@
+// The file contents for the current environment will overwrite these during build.
+// The build system defaults to the dev environment which uses `environment.ts`, but if you do
+// `ng build --configuration=production` then `environment.prod.ts` will be used instead.
+// The list of which env maps to which file can be found in configurations section of `angular.json`.
+export const environment = {
+  production: false,
+  skipGlobalLogin: true,
+  appkey: 'b11e7c189b',
+  pusherKey: '255f010d210933ca7675',
+  env: 'local',
+  // APIEndpoint: 'https://sandbox.practera.com/',
+  // graphQL: 'https://kixs5acl6j.execute-api.ap-southeast-2.amazonaws.com/sandbox/',
+  APIEndpoint: 'http://127.0.0.1:8080/',
+  graphQL: 'http://127.0.0.1:8000/',
+  intercomAppId: '',
+  filestack: {
+    key: 'AO6F4C72uTPGRywaEijdLz',
+    s3Config: {
+      location: 's3',
+      container: 'practera-aus',
+      containerChina: 'practera-kr',
+      region: 'ap-southeast-2',
+      regionChina: 'ap-northeast-2',
+      paths: {
+        any: '/appv2/stage/uploads/',
+        image: '/appv2/stage/uploads/',
+        video: '/appv2/stage/video/upload/'
+      },
+      workflows: [
+        '3c38ef53-a9d0-4aa4-9234-617d9f03c0de',
+      ],
+    },
+    policy: '<CUSTOM_FILESTACK_POLICY>',
+    signature: '<CUSTOM_FILESTACK_SIGNATURE>',
+    workflows: {
+      virusDetection: '3c38ef53-a9d0-4aa4-9234-617d9f03c0de',
+    },
+  },
+  defaultCountryModel: 'AUS',
+  intercom: false,
+  goMobile: false,
+};
+
+/*
+ * In development mode, to ignore zone related error stack frames such as
+ * `zone.run`, `zoneDelegate.invokeTask` for easier debugging, you can
+ * import the following file, but please comment it out in production mode
+ * because it will have performance impact when throw error
+ */
+// import 'zone.js/dist/zone-error';  // Included with Angular CLI.


### PR DESCRIPTION
…in multiple cohorts within the same program/experience. It ensures the timeline title is displayed as a subtitle in the switcher - this way you can tell the difference between two timelines in the same experience.

**Story/Ticket Reference ID from JIRA:**
`Add link here`

**Additional Comments:**
`Add here`

**Checklist:**

- [ x ] Unit test completed?: (Y/N)
- [ x ] Docs folder up to date?: (Y/N)
- [ x ] Add if anything missed: (Y/N)

All Checklist are okay.

This PR looks great - it's ready to merge! Please review and let's ship it. :)
