### PR TITLE
[CORE-4294] add service header to global login api call

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -100,8 +100,8 @@ export class AppComponent implements OnInit {
     }
     searchParams = new URLSearchParams(queryString);
 
-    if (searchParams.has('apikey')) {
-      return this.navigate(['global_login', searchParams.get('apikey')]);
+    if (searchParams.has('apikey') && searchParams.has('service')) {
+      return this.navigate(['global_login', searchParams.get('apikey'), searchParams.get('service')]);
     }
 
     if (searchParams.has('do')) {

--- a/src/app/auth/auth-global-login/auth-global-login.component.ts
+++ b/src/app/auth/auth-global-login/auth-global-login.component.ts
@@ -24,12 +24,13 @@ export class AuthGlobalLoginComponent implements OnInit {
   async ngOnInit() {
     this.newRelic.setPageViewName('global-login');
     const apikey = this.route.snapshot.paramMap.get('apikey');
+    const service = this.route.snapshot.paramMap.get('service');
     if (!apikey) {
       return this._error();
     }
 
     try {
-      await this.authService.globalLogin({ apikey }).toPromise();
+      await this.authService.globalLogin({ apikey, service }).toPromise();
       await this.switcherService.getMyInfo().toPromise();
       this.newRelic.createTracer('Processing global login');
       return this.navigate(['switcher', 'switcher-program']);

--- a/src/app/auth/auth-routing.module.ts
+++ b/src/app/auth/auth-routing.module.ts
@@ -50,7 +50,7 @@ const routes: Routes = [
         component: AuthDirectLoginComponent,
       },
       {
-        path: 'global_login/:apikey',
+        path: 'global_login/:apikey/:service',
         component: AuthGlobalLoginComponent,
       }
     ]

--- a/src/app/auth/auth.service.spec.ts
+++ b/src/app/auth/auth.service.spec.ts
@@ -137,7 +137,7 @@ describe('AuthService', () => {
       }
     }));
     storageSpy.getConfig.and.returnValue(true);
-    service.globalLogin({ apikey: 'abcd' }).subscribe();
+    service.globalLogin({ apikey: 'abcd', service: 'LOGIN' }).subscribe();
     expect(requestSpy.post.calls.count()).toBe(1);
     expect(requestSpy.post.calls.first().args[1]).toContain('abcd');
     expect(storageSpy.setUser.calls.first().args[0]).toEqual({apikey: '123456'});

--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -77,9 +77,12 @@ export class AuthService {
     // do clear user cache here
   }
 
-  private _login(body: HttpParams) {
+  private _login(body: HttpParams, serviceHeader?: string) {
     return this.request.post(api.login, body.toString(), {
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        service: serviceHeader
+       }
     }).pipe(map(res => this._handleLoginResponse(res)));
   }
 
@@ -119,11 +122,11 @@ export class AuthService {
    *              so must convert them into compatible formdata before submission
    * @param {object} { apikey } in string
    */
-  globalLogin({ apikey }): Observable<any> {
+  globalLogin({ apikey, service }): Observable<any> {
     const body = new HttpParams()
       .set('apikey', apikey);
     this.logout({}, false);
-    return this._login(body);
+    return this._login(body, service);
   }
 
   private _handleLoginResponse(response): Observable<any> {


### PR DESCRIPTION
added service pram to routes.
update auth service to send service header in login api call.
updated global login component to get header from route and pass to service
update app component to pass service pram to global login component.

**Story/Ticket Reference ID from JIRA:**
https://intersective.atlassian.net/browse/CORE-4294

**Additional Comments:**
`Add here`

**Checklist:**

- [ x ] Unit test completed?: (Y)
All Checklist are okay.

This PR looks great - it's ready to merge! Please review and let's ship it. :)
