### PR TITLE
Add timezone information to events in app

### DIFF
--- a/src/app/event-detail/event-detail.component.html
+++ b/src/app/event-detail/event-detail.component.html
@@ -21,7 +21,7 @@
     </ion-item>
     <ion-item>
       <ion-icon class="leading-icon gray-2" name="time-outline"></ion-icon>
-      <div id="time" class="subtitle-1">{{ utils.utcToLocal(event.startTime, 'time') }} - {{ utils.utcToLocal(event.endTime, 'time') }}</div>
+      <div id="time" class="subtitle-1">{{ utils.utcToLocal(event.startTime, 'time') }} - {{ utils.utcToLocal(event.endTime, 'time') }} {{utils.localTimezone()}} </div>
     </ion-item>
     <ng-container *ngIf="event.videoConference">
       <ion-item *ngIf="!event.isBooked" class="zoom-meeting">

--- a/src/app/services/utils.service.ts
+++ b/src/app/services/utils.service.ts
@@ -281,6 +281,27 @@ export class UtilsService {
     }).format(dateToFormat.toDate());
   }
 
+  localTimezone() {
+    const today = new Date();
+    const short = today.toLocaleDateString(undefined);
+    const full = today.toLocaleDateString(undefined, { timeZoneName: 'long' });
+
+    // Trying to remove date from the string in a locale-agnostic way
+    const shortIndex = full.indexOf(short);
+    if (shortIndex >= 0) {
+      const trimmed = full.substring(0, shortIndex) + full.substring(shortIndex + short.length);
+      
+      // by this time `trimmed` should be the timezone's name with some punctuation -
+      // trim it from both sides
+      return trimmed.replace(/^[\s,.\-:;]+|[\s,.\-:;]+$/g, '');
+
+    } else {
+      // in some magic case when short representation of date is not present in the long one, just return the long one as a fallback, since it should contain the timezone's name
+      return Intl.DateTimeFormat().resolvedOptions().timeZone;
+    }
+      
+  }
+
   /**
    * @description dates comparison (between today/provided date)
    * @param {Date    | string} timeString [description]


### PR DESCRIPTION
**Story/Ticket Reference ID from JIRA:**
`Add link here`

**Additional Comments:**
It is important for our users who are operating in multiple timezones to know which timezone the event time refers.

This is one possible solution - open to others. 

**Checklist:**

- [x] Unit test completed?: (Y/N)
- [x] Docs folder up to date?: (Y/N)
- [x] Add if anything missed: (Y/N)

All checklists are okay.

This PR looks great - it's ready to merge! Please review and let's ship it. :)
