### PR TITLE
[AV2-929] Chat messages duplicate visually when scrolling up to see older messages.

### DIFF
--- a/src/app/chat/chat-room/chat-room.component.ts
+++ b/src/app/chat/chat-room/chat-room.component.ts
@@ -165,13 +165,11 @@ export class ChatRoomComponent extends RouterEnter {
       .subscribe(
         (messageListResult: MessageListResult) => {
           if (!messageListResult) {
-            this.messagePageCursor = '';
             this.loadingChatMessages = false;
             return;
           }
           let messages = messageListResult.messages;
           if (messages.length === 0) {
-            this.messagePageCursor = '';
             this.loadingChatMessages = false;
             return;
           }


### PR DESCRIPTION
**Story/Ticket Reference ID from JIRA:**
https://intersective.atlassian.net/browse/AV2-929

**Additional Comments:**
This is happening in stage also not only uk server.
remove code, making cursor empty every time there are no messages.

**Checklist:**

- [x] Unit test completed?: (Y/N)
- [x] Docs folder up to date?: (Y/N)
- [x] Add if anything missed: (Y/N)

All checklists are okay.

This PR looks great - it's ready to merge! Please review and let's ship it. :)
