### PR TITLE
[AV2-954] event not showing when navigate from an event item in Activity Page

### DIFF
--- a/src/app/event-list/event-list.service.ts
+++ b/src/app/event-list/event-list.service.ts
@@ -80,8 +80,12 @@ export class EventListService {
     const params: any = {
       types: ['activity_session', 'other']
     };
+    // getting events link with activity
     if (activityId) {
       params.activity_id = activityId;
+      // remove 'other' from the event types.
+      // because 'other' type events not link with activity.
+      params.types.splice(1, 1);
     }
 
     return this.request.get(api.get.events, {params: params})

--- a/src/app/event-list/event-list.service.ts
+++ b/src/app/event-list/event-list.service.ts
@@ -83,9 +83,7 @@ export class EventListService {
     // getting events link with activity
     if (activityId) {
       params.activity_id = activityId;
-      // remove 'other' from the event types.
-      // because 'other' type events not link with activity.
-      params.types.splice(1, 1);
+      params.types = ['activity_session'];
     }
 
     return this.request.get(api.get.events, {params: params})


### PR DESCRIPTION
**Story/Ticket Reference ID from JIRA:**
https://intersective.atlassian.net/browse/AV2-954

**Additional Comments:**
add code to remove 'other' type when getting events link to an activity.
Because 'other' type events are not link with any activity. so we no need to show them in activity page.

**Checklist:**

- [x] Unit test completed?: (Y/N)
- [x] Docs folder up to date?: (Y/N)
- [x] Add if anything missed: (Y/N)

All checklists are okay.

This PR looks great - it's ready to merge! Please review and let's ship it. :)
