### PR TITLE
[AV2-973] Replace the Greyed Submit button to Practera logo loading

### DIFF
--- a/src/app/assessment/assessment.component.html
+++ b/src/app/assessment/assessment.component.html
@@ -176,15 +176,18 @@
       style="width: 100%"
     ></ion-spinner>
     <ng-container *ngIf="!loadingAssessment">
-      <ion-button
+      <img *ngIf="savingButtonDisabled; else submitTmp" class="footer-action" src="/assets/loading.gif" alt="loading">
+      <ng-template #submitTmp>
+        <ion-button
         *ngIf="(doAssessment || doReview) && !submitting && !submitted"
         id="btn-submit"
-        [disabled]="questionsForm.invalid || savingButtonDisabled"
+        [disabled]="questionsForm.invalid"
         (click)="submit(false)"
         shape="round"
         fill="clear"
         class="footer-action"
         >SUBMIT</ion-button>
+      </ng-template>
 
       <ng-container *ngIf="footerText()">
         <span class="footer-text ion-float-left">{{ footerText() }}</span>

--- a/src/app/assessment/assessment.component.spec.ts
+++ b/src/app/assessment/assessment.component.spec.ts
@@ -354,7 +354,7 @@ describe('AssessmentComponent', () => {
         expect(component.submission).toEqual(tmpSubmission);
         expect(component.doAssessment).toBe(false);
         expect(component.doReview).toBe(false);
-        expect(component.savingButtonDisabled).toBe(true);
+        expect(component.savingButtonDisabled).toBe(false);
       };
     });
 
@@ -381,7 +381,7 @@ describe('AssessmentComponent', () => {
         expect(component.review).toEqual(tmpReview);
         expect(component.doAssessment).toBe(false, 'not do assessment');
         expect(component.doReview).toBe(false, 'not do review');
-        expect(component.savingButtonDisabled).toBe(true);
+        expect(component.savingButtonDisabled).toBe(false);
         expect(component.feedbackReviewed).toBe(false);
       };
     });

--- a/src/app/assessment/assessment.component.ts
+++ b/src/app/assessment/assessment.component.ts
@@ -200,7 +200,7 @@ export class AssessmentComponent extends RouterEnter {
     this.questionsForm = new FormGroup({});
     this.submitting = false;
     this.submitted = false;
-    this.savingButtonDisabled = true;
+    this.savingButtonDisabled = false;
     this.savingMessage = '';
     this.continueBtnLoading = false;
   }

--- a/src/app/chat/chat-view/chat-view.component.spec.ts
+++ b/src/app/chat/chat-view/chat-view.component.spec.ts
@@ -58,4 +58,33 @@ describe('ChatViewComponent', () => {
     });
   });
 
+  describe('when testing goto()', () => {
+    it(`should call chat room onEnter`, fakeAsync(() => {
+      spyOn(component.chatRoom, 'onEnter');
+      const chatChannel = {
+        uuid: '35326928',
+        name: 'Team 1',
+        avatar: 'https://sandbox.practera.com/img/team-white.png',
+        pusherChannel: 'sdb746-93r7dc-5f44eb4f',
+        isAnnouncement: false,
+        isDirectMessage: false,
+        readonly: false,
+        roles: [
+          'participant',
+          'coordinator',
+          'admin'
+        ],
+        unreadMessageCount: 0,
+        lastMessage: null,
+        lastMessageCreated: null,
+        canEdit: false
+      };
+      component.goto(chatChannel);
+      expect(component.loadInfo).toBe(false);
+      expect(component.chatChannel).toEqual(chatChannel);
+      tick();
+      expect(component.chatRoom.onEnter).toHaveBeenCalled();
+    }));
+  });
+
 });


### PR DESCRIPTION
**Story/Ticket Reference ID from JIRA:**
https://intersective.atlassian.net/browse/AV2-973

**Additional Comments:**
add code to replace submit btn with loading when save on going.

**Checklist:**

- [x] Unit test completed?: (Y/N)
- [x] Docs folder up to date?: (Y/N)
- [x] Add if anything missed: (Y/N)

All checklists are okay.

This PR looks great - it's ready to merge! Please review and let's ship it. :)
