### PR TITLE
[CORE-6580] Bugfix/refactor query auth usage

### DIFF
--- a/projects/v3/src/app/pages/auth/auth-direct-login/auth-direct-login.component.ts
+++ b/projects/v3/src/app/pages/auth/auth-direct-login/auth-direct-login.component.ts
@@ -37,6 +37,8 @@ export class AuthDirectLoginComponent implements OnInit {
 
       this.experienceService.switchProgram({
         experience: authed.experience
+      }, {
+        refreshJWT: false, // avoid 2nd call to auth query
       });
       return this._redirect({ experience: authed.experience });
     } catch (err) {

--- a/projects/v3/src/app/pages/auth/auth-direct-login/auth-direct-login.component.ts
+++ b/projects/v3/src/app/pages/auth/auth-direct-login/auth-direct-login.component.ts
@@ -35,11 +35,6 @@ export class AuthDirectLoginComponent implements OnInit {
       const authed = await this.authService.autologin({ authToken }).toPromise();
       await this.experienceService.getMyInfo().toPromise();
 
-      this.experienceService.switchProgram({
-        experience: authed.experience
-      }, {
-        refreshJWT: false, // avoid 2nd call to auth query
-      });
       return this._redirect({ experience: authed.experience });
     } catch (err) {
       console.error(err);
@@ -94,9 +89,9 @@ export class AuthDirectLoginComponent implements OnInit {
     const restrictedAccess = this.singlePageRestriction();
 
     // switch program directly if user already registered
-    if (!redirectLater) {
+    if (!redirectLater && experience) {
       await this.experienceService.switchProgram({
-        experience: this.storage.get('experience')
+        experience
       });
     }
 

--- a/projects/v3/src/app/pages/experiences/experiences.page.html
+++ b/projects/v3/src/app/pages/experiences/experiences.page.html
@@ -41,21 +41,21 @@
                 <ion-grid>
                   <ion-row>
 
-                  <ng-container *ngFor="let program of experiences">
+                  <ng-container *ngFor="let experience of experiences">
                     <ion-col class="ion-align-self-center" size="12" size-sm="6" size-md="4">
                       <ion-card class="exp-card ion-no-margin"
-                        [attr.aria-label]="program.name"
-                        (click)="switchProgram(program)" (keydown)="switchProgram(program, $event)" tabindex="0">
+                        [attr.aria-label]="experience.name"
+                        (click)="switchProgram(experience)" (keydown)="switchProgram(experience, $event)" tabindex="0">
                         <div class="exp-image-container">
                           <img
-                          [src]="program.leadImage ? program.leadImage : '../../../assets/default-experience-image.svg'"
-                          [attr.alt]="program.name + ' experience selection'">
+                          [src]="experience.leadImage ? experience.leadImage : '../../../assets/default-experience-image.svg'"
+                          [attr.alt]="experience.name + ' experience selection'">
                         </div>
                         <ion-card-content>
-                          <p class="m-0 headline-3 exp-title black">{{ program.name }}</p>
+                          <p class="m-0 headline-3 exp-title black">{{ experience.name }}</p>
                           <div class="exp-info subtitle-3 grey-50"
-                             *ngIf="progresses[program.projectId]">
-                            <p class="m-0 subtitle-3 grey-50" i18n>{{progresses[program.projectId]}}% Progress</p>
+                             *ngIf="progresses[experience.projectId]">
+                            <p class="m-0 subtitle-3 grey-50" i18n>{{progresses[experience.projectId]}}% Progress</p>
                           </div>
                         </ion-card-content>
                       </ion-card>

--- a/projects/v3/src/app/pages/experiences/experiences.page.ts
+++ b/projects/v3/src/app/pages/experiences/experiences.page.ts
@@ -82,7 +82,7 @@ export class ExperiencesPage implements OnInit, OnDestroy {
     return this.storage.getConfig().instituteLogo;
   }
 
-  async switchProgram(program: ProgramObj, keyEvent?: KeyboardEvent) {
+  async switchProgram(experience: ProgramObj, keyEvent?: KeyboardEvent) {
     if (keyEvent && (keyEvent.code === 'Enter' || keyEvent.code === 'Space')) {
       keyEvent.preventDefault();
     } else if (keyEvent) {
@@ -96,7 +96,7 @@ export class ExperiencesPage implements OnInit, OnDestroy {
     await loading.present();
     try {
       this.unlockIndicatorService.clearAllTasks(); // reset indicators
-      const route = await this.experienceService.switchProgramAndNavigate(program);
+      const route = await this.experienceService.switchProgramAndNavigate(experience);
       await loading.dismiss();
       if (environment.demo) {
         destination = ['v3','home'];

--- a/projects/v3/src/app/services/auth.service.ts
+++ b/projects/v3/src/app/services/auth.service.ts
@@ -95,7 +95,7 @@ export class AuthService {
     private unlockIndicatorService: UnlockIndicatorService,
   ) { }
 
-  authenticate(data: {
+  authenticate(data?: {
     authToken?: string;
     apikey?: string;
     service?: string;
@@ -115,31 +115,34 @@ export class AuthService {
       };
     } = {};
 
-    // Initialize options.variables
-    if (data.authToken || data.experienceUuid) {
-      options.variables = {};
-    }
+    if (data) {
 
-    if (data.authToken) {
-      options.variables.authToken = data.authToken;
-    }
+      // Initialize options.variables
+      if (data.authToken || data.experienceUuid) {
+        options.variables = {};
+      }
 
-    if (data.experienceUuid) {
-      options.variables.experienceUuid = data.experienceUuid;
-    }
+      if (data.authToken) {
+        options.variables.authToken = data.authToken;
+      }
 
-    // Initialize options.headers
-    if (data.apikey || data.service) {
-      options.context = { headers: {} };
-    }
+      if (data.experienceUuid) {
+        options.variables.experienceUuid = data.experienceUuid;
+      }
 
-    if (data.apikey) {
-      this.storage.setUser({ apikey: data.apikey });
-      options.context.headers.apikey = data.apikey;
-    }
+      // Initialize options.headers
+      if (data.apikey || data.service) {
+        options.context = { headers: {} };
+      }
 
-    if (data.service) {
-      options.context.headers.service = data.service;
+      if (data.apikey) {
+        this.storage.setUser({ apikey: data.apikey });
+        options.context.headers.apikey = data.apikey;
+      }
+
+      if (data.service) {
+        options.context.headers.service = data.service;
+      }
     }
 
     return this.apolloService.graphQLFetch(`
@@ -179,8 +182,6 @@ export class AuthService {
       options
     ).pipe(
       map((res: AuthEndpoint)=> {
-        console.log('auth-res::', res);
-
         if (res?.data?.auth?.unregistered === true) {
           // [CORE-6011] trusting API returns email and activationCode
           const { email, activationCode } = res.data.auth;
@@ -214,7 +215,7 @@ export class AuthService {
     service?: string;
   }): Observable<any> {
     this.logout({}, false);
-    return this.authenticate({...data, ...{service: 'LOGIN'}}).pipe(
+    return this.authenticate({...data, ...{ service: 'LOGIN' }}).pipe(
       map(res => this._handleAuthResponse(res)),
     );
   }

--- a/projects/v3/src/app/services/auth.service.ts
+++ b/projects/v3/src/app/services/auth.service.ts
@@ -179,6 +179,8 @@ export class AuthService {
       options
     ).pipe(
       map((res: AuthEndpoint)=> {
+        console.log('auth-res::', res);
+
         if (res?.data?.auth?.unregistered === true) {
           // [CORE-6011] trusting API returns email and activationCode
           const { email, activationCode } = res.data.auth;
@@ -217,7 +219,14 @@ export class AuthService {
     );
   }
 
-  private _handleAuthResponse(res): {
+  private _handleAuthResponse(res: {
+    data: {
+      auth: {
+        apikey: string;
+        experience: object;
+      }
+    }
+  }): {
     apikey?: string;
     experience?: object;
   } {

--- a/projects/v3/src/app/services/experience.service.ts
+++ b/projects/v3/src/app/services/experience.service.ts
@@ -232,7 +232,9 @@ export class ExperienceService {
     };
   }
 
-  async switchProgram(authObj): Promise<Observable<any>> {
+  async switchProgram(authObj, options?: {
+    refreshJWT?: boolean;
+  }): Promise<Observable<any>> {
     const exp = authObj?.experience;
     this.storage.set('experience', exp);
     const colors = {
@@ -275,14 +277,17 @@ export class ExperienceService {
     // initialise Pusher
     this.sharedService.initWebServices();
     try {
-      const newAuth = await this.authService.authenticate({
-        apikey: this.storage.getUser().apikey,
-        experienceUuid: exp.uuid
-      }).toPromise();
+      let newAuth = authObj;
+      if (options.refreshJWT === true) {
+        newAuth = await this.authService.authenticate({
+          apikey: this.storage.getUser().apikey,
+          experienceUuid: exp.uuid
+        }).toPromise();
 
-      // reset apikey
-      if (newAuth?.data?.auth?.apikey) {
-        this.storage.setUser({ apikey: newAuth?.data?.auth?.apikey });
+        // reset apikey
+        if (newAuth?.data?.auth?.apikey) {
+          this.storage.setUser({ apikey: newAuth?.data?.auth?.apikey });
+        }
       }
 
       const teamInfo = await this.sharedService.getTeamInfo().toPromise();

--- a/projects/v3/src/app/services/experience.service.ts
+++ b/projects/v3/src/app/services/experience.service.ts
@@ -232,16 +232,22 @@ export class ExperienceService {
     };
   }
 
-  async switchProgram(authObj, options?: {
-    refreshJWT?: boolean;
-  }): Promise<Observable<any>> {
+  /**
+   * insert experience to localStorage and switch program
+   *
+   * @param   {any}  authObj  auth object return from authService:authenticate()
+   * @param   {object}  options  refreshJWT: boolean, 2nd call to auth query to refresh APIKEY
+   *
+   * @return  {Promise<any>}
+   */
+  async switchProgram(authObj): Promise<any> {
     const exp = authObj?.experience;
     this.storage.set('experience', exp);
     const colors = {
       themeColor: exp?.color,
       primary: exp?.color,
       secondary: exp?.secondaryColor,
-    }
+    };
 
     const cardBackgroundImage = (exp?.cardUrl) ? '/assets/' + exp?.cardUrl : '';
     this.storage.setUser({
@@ -277,25 +283,12 @@ export class ExperienceService {
     // initialise Pusher
     this.sharedService.initWebServices();
     try {
-      let newAuth = authObj;
-      if (options.refreshJWT === true) {
-        newAuth = await this.authService.authenticate({
-          apikey: this.storage.getUser().apikey,
-          experienceUuid: exp.uuid
-        }).toPromise();
-
-        // reset apikey
-        if (newAuth?.data?.auth?.apikey) {
-          this.storage.setUser({ apikey: newAuth?.data?.auth?.apikey });
-        }
-      }
-
       const teamInfo = await this.sharedService.getTeamInfo().toPromise();
       const me = await this.getMyInfo().toPromise();
 
       this._experience$.next(exp);
 
-      return of([newAuth, teamInfo, me]);
+      return [teamInfo, me];
     } catch (err) {
       throw Error(err);
     }

--- a/projects/v3/src/app/services/home.service.ts
+++ b/projects/v3/src/app/services/home.service.ts
@@ -82,7 +82,7 @@ export class HomeService {
       return this.demo.experience().pipe(map(res => this._normaliseExperience(res))).subscribe();
     }
 
-    return this.authService.authenticate({ apikey }).pipe(
+    return this.authService.authenticate().pipe(
       tap(async res => {
         if (res?.data?.auth?.experience === null) {
           await this.notificationsService.alert({

--- a/projects/v3/src/app/services/shared.service.ts
+++ b/projects/v3/src/app/services/shared.service.ts
@@ -215,6 +215,8 @@ export class SharedService {
     this.utils.checkIsPracteraSupportEmail();
   }
 
+  // a new APIKEY will returned from API, it auto refresh key through
+  // requestInterceptor[_refreshApikey]
   getNewJwt() {
     return this.requestService.get(api.get.jwt);
   }


### PR DESCRIPTION
change:
- since query auth returns experience in the API, no longer need to make extra call with `experinceUuid` to retrieve experience data (removed code to do 2nd pull with `experienceUuid`
- bugfix: an promise didn't deferred properly, suspect it's the cause of potential login issue with some user. (added await to experienceService.switchProgram())