### PR TITLE
[CORE-6653] retire core jwt refresh - prerelease

### DIFF
--- a/projects/v3/src/app/pages/chat/chat-view/chat-view.component.ts
+++ b/projects/v3/src/app/pages/chat/chat-view/chat-view.component.ts
@@ -3,7 +3,7 @@ import { Router, ActivatedRoute, ParamMap } from '@angular/router';
 import { UtilsService } from '@v3/services/utils.service';
 import { ChatChannel } from '@v3/services/chat.service';
 import { DOCUMENT } from '@angular/common';
-import { SharedService } from '@v3/app/services/shared.service';
+import { AuthService } from '@v3/app/services/auth.service';
 
 @Component({
   selector: 'app-chat-view',
@@ -21,7 +21,7 @@ export class ChatViewComponent implements OnInit {
 
   constructor(
     private route: ActivatedRoute,
-    private sharedService: SharedService,
+    private authService: AuthService,
     private utils: UtilsService,
     @Inject(DOCUMENT) private readonly document: Document
   ) {
@@ -40,7 +40,7 @@ export class ChatViewComponent implements OnInit {
   private _initialise() {
     this.chatChannel = null;
     this.loadInfo = false;
-    this.sharedService.getNewJwt().subscribe();
+    this.authService.authenticate().subscribe();
   }
 
   // navigate to a chat-room (on desktop only)

--- a/projects/v3/src/app/pages/devtool/devtool.page.ts
+++ b/projects/v3/src/app/pages/devtool/devtool.page.ts
@@ -37,7 +37,7 @@ export class DevtoolPage implements OnInit {
   }
 
   refresh() {
-    this.sharedService.getNewJwt().subscribe();
+    this.authService.authenticate().subscribe();
   }
 
   login() {

--- a/projects/v3/src/app/services/auth.service.ts
+++ b/projects/v3/src/app/services/auth.service.ts
@@ -65,19 +65,45 @@ interface ExperienceConfig {
   logo: string;
 }
 
-interface AuthEndpoint {
+export interface AuthEndpoint {
   data: {
     auth: {
       apikey: string;
-      experience: {
-        cardUrl?: string;
-        [key: string]: any; // default card activity image
-      };
+      experience: AuthEndpointExperience;
       email?: string;
       unregistered?: boolean;
       activationCode?: string;
     }
   }
+}
+
+interface AuthEndpointExperience {
+  id: number;
+  uuid: string;
+  timelineId: number;
+  projectId: number;
+  name: string;
+  description: string;
+  type: string;
+  leadImage: string;
+  status: null | string;
+  setupStep: null | string;
+  color: string;
+  secondaryColor: string;
+  role: string;
+  isLast: null | boolean;
+  locale: string;
+  supportName: string;
+  supportEmail: string;
+  cardUrl: string;
+  bannerUrl: string;
+  logoUrl: string;
+  iconUrl: string;
+  reviewRating: boolean;
+  truncateDescription: boolean;
+  team: {
+    id: number;
+  };
 }
 
 interface AuthQuery {
@@ -191,6 +217,9 @@ export class AuthService {
             iconUrl
             reviewRating
             truncateDescription
+            team {
+              id
+            }
           }
           email
           unregistered

--- a/projects/v3/src/app/services/request.interceptor.ts
+++ b/projects/v3/src/app/services/request.interceptor.ts
@@ -79,8 +79,9 @@ export class RequestInterceptor implements HttpInterceptor {
    * Refresh the apikey (JWT token) if API returns it
    */
   private _refreshApikey(response: HttpResponse<any>) {
-    if (response && response?.body?.data?.apikey) {
-      this.storage.setUser({ apikey: response.body.data.apikey });
+    const newApikeyFromAPI = response?.body?.data?.auth?.apikey;
+    if (newApikeyFromAPI) {
+      this.storage.setUser({ apikey: newApikeyFromAPI });
     }
   }
 }


### PR DESCRIPTION
https://intersective.atlassian.net/browse/CORE-6653

changes:
- replaced CORE API with graphql Auth query for jwt refresh
- request inteceptor to update jwt whenever Auth Query return any
- team is also updated if different one found (compared with cache) when auth query has new one returned