### PR TITLE
[CORE-7653] handle large tablet viewport flexibly

### DIFF
--- a/projects/v3/src/app/components/review-rating/review-rating.component.ts
+++ b/projects/v3/src/app/components/review-rating/review-rating.component.ts
@@ -1,3 +1,4 @@
+import { firstValueFrom } from 'rxjs';
 import { Component, Input, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { ModalController } from '@ionic/angular';
@@ -84,7 +85,7 @@ export class ReviewRatingComponent implements OnInit {
     this.ratingData.rating = +(this.ratingData.rating.toFixed(2));
 
     try {
-      await this.reviewRatingService.submitRating(this.ratingData).toPromise();
+      await firstValueFrom(this.reviewRatingService.submitRating(this.ratingData));
       this.isSubmitting = false;
       this.ratingSessionEnd = true;
     } catch (err) {

--- a/projects/v3/src/app/pages/tabs/tabs.page.ts
+++ b/projects/v3/src/app/pages/tabs/tabs.page.ts
@@ -1,5 +1,5 @@
-import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
-import { IonTabs, Platform } from '@ionic/angular';
+import { Component, HostListener, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { IonTabs } from '@ionic/angular';
 import { ActivatedRoute } from '@angular/router';
 import { Review, ReviewService } from '@v3/services/review.service';
 import { BrowserStorageService } from '@v3/services/storage.service';
@@ -29,8 +29,9 @@ export class TabsPage implements OnInit, OnDestroy {
     chat: 0,
   };
 
+  isMobile: boolean;
+
   constructor(
-    private platform: Platform,
     private reviewService: ReviewService,
     private storageService: BrowserStorageService,
     private chatService: ChatService,
@@ -38,7 +39,9 @@ export class TabsPage implements OnInit, OnDestroy {
     private notificationsService: NotificationsService,
     private route: ActivatedRoute,
     private activityService: ActivityService,
-  ) {}
+  ) {
+    this.handleResize();
+  }
 
   ngOnInit() {
     this.subscriptions.push(this.reviewService.reviews$.subscribe(res => this.reviews = res));
@@ -97,10 +100,6 @@ export class TabsPage implements OnInit, OnDestroy {
     });
   }
 
-  get isMobile() {
-    return this.utils.isMobile();
-  }
-
   ngOnDestroy(): void {
     this.subscriptions.forEach(sub => {
       if (sub.closed === false) {
@@ -111,5 +110,10 @@ export class TabsPage implements OnInit, OnDestroy {
 
   setCurrentTab() {
     this.selectedTab = this.tabs.getSelected();
+  }
+
+  @HostListener('window:resize', ['$event'])
+  handleResize() {
+    this.isMobile = this.utils.isMobile();
   }
 }

--- a/projects/v3/src/app/pages/v3/v3.page.html
+++ b/projects/v3/src/app/pages/v3/v3.page.html
@@ -1,4 +1,4 @@
-<ion-split-pane contentId="main-content" [when]="isMobile? 'lg' : '(min-width: 0px)'">
+<ion-split-pane contentId="main-content" [when]="isMobile? 'xl' : '(min-width: 0px)'">
   <ion-menu contentId="main-content"
     [ngClass]="{'collapsed': !isMobile && !openMenu}"
     [@openClose]="collapsibleMenu"

--- a/projects/v3/src/app/pages/v3/v3.page.ts
+++ b/projects/v3/src/app/pages/v3/v3.page.ts
@@ -1,5 +1,5 @@
 import { take, takeUntil, mergeMap } from 'rxjs/operators';
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, HostListener, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import { MenuController, ModalController } from '@ionic/angular';
 import { Review, ReviewService } from '@v3/app/services/review.service';
@@ -99,6 +99,11 @@ export class V3Page implements OnInit, OnDestroy {
     this.isMobile = this.utils.isMobile();
   }
 
+  @HostListener('window:resize', ['$event'])
+  ionViewDidEnter() {
+    this.isMobile = this.utils.isMobile();
+  }
+
   ngOnDestroy(): void {
     this.unsubscribe$.next();
     this.unsubscribe$.complete();
@@ -177,7 +182,6 @@ export class V3Page implements OnInit, OnDestroy {
         }
       });
       this.appPages[3].badges = chat?.unreadMessages || 0; // messages tab
-
       this.appPages[1].badges = notifications.filter(noti => noti.type === 'event-reminder').length; // events tab
       this.appPages[2].badges = notifications.filter(noti => noti.type === 'review_submission').length; // reviews tab
     });

--- a/projects/v3/src/app/services/utils.service.ts
+++ b/projects/v3/src/app/services/utils.service.ts
@@ -64,10 +64,35 @@ export class UtilsService {
   }
 
   /**
+   * get orientation of the device by comparing window height and width
+   *
+   * @return  {boolean} true if portrait, false if landscape
+   */
+  isPortrait(): boolean {
+    return window.innerHeight > window.innerWidth ? true : false;
+  }
+
+  /**
+   * Treat viewport size start from large tablet as desktop
+   * grouping device type into 2 group (mobile/desktop)
    * @name isMobile
-   * @description grouping device type into 2 group (mobile/desktop) and return true if mobile, otherwise return false
+   * @return {boolean} true if mobile, false if desktop
    */
   isMobile(): boolean {
+    if (this.platform.is('desktop')) {
+      return false;
+    }
+
+    if (this.platform.is('tablet')) {
+      if (window.innerWidth < 1024) {
+        return true;
+      }
+
+      // for larger tablet (iPad Pro & samsung 10)
+      // considered as desktop (1024px = logical viewport)
+      return false;
+    }
+
     return this.platform.is('mobile');
   }
 


### PR DESCRIPTION
changes
- added support for large tablet logical viewport (1024px)
- logical viewport now grouped into 2, 
  - normal tablet like iPad mini or samsung tab s9, 
  - large tablet like > 10in  (samsung tab 10s or ipad air/pro 10 or 13in)
[[CORE-7653]](https://intersective.atlassian.net/browse/CORE-7653)

[CORE-7653]: https://intersective.atlassian.net/browse/CORE-7653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ