### PR TITLE
[CORE-7653] 2.4.2.2/viewport tablets 

### DIFF
--- a/projects/v3/src/app/app.component.ts
+++ b/projects/v3/src/app/app.component.ts
@@ -192,6 +192,10 @@ export class AppComponent implements OnInit, OnDestroy {
 
   // redirect to the last visited url/assessment if available
   redirectToLastVisitedUrl(): Promise<boolean> {
+    if (this.noneCachedUrl.some((url) => window.location?.href?.includes(url))) {
+      return this.navigate(window.location.href);
+    }
+
     const lastVisitedUrl = this.storage.lastVisited("url") as string;
     if (lastVisitedUrl) {
       const lastVisitedAssessmentUrl = this.storage.lastVisited("assessmentUrl");

--- a/projects/v3/src/app/components/review-rating/review-rating.component.ts
+++ b/projects/v3/src/app/components/review-rating/review-rating.component.ts
@@ -1,3 +1,4 @@
+import { firstValueFrom } from 'rxjs';
 import { Component, Input, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { ModalController } from '@ionic/angular';
@@ -84,7 +85,7 @@ export class ReviewRatingComponent implements OnInit {
     this.ratingData.rating = +(this.ratingData.rating.toFixed(2));
 
     try {
-      await this.reviewRatingService.submitRating(this.ratingData).toPromise();
+      await firstValueFrom(this.reviewRatingService.submitRating(this.ratingData));
       this.isSubmitting = false;
       this.ratingSessionEnd = true;
     } catch (err) {

--- a/projects/v3/src/app/components/review-rating/review-rating.component.ts
+++ b/projects/v3/src/app/components/review-rating/review-rating.component.ts
@@ -1,4 +1,3 @@
-import { firstValueFrom } from 'rxjs';
 import { Component, Input, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { ModalController } from '@ionic/angular';
@@ -85,7 +84,7 @@ export class ReviewRatingComponent implements OnInit {
     this.ratingData.rating = +(this.ratingData.rating.toFixed(2));
 
     try {
-      await firstValueFrom(this.reviewRatingService.submitRating(this.ratingData));
+      await this.reviewRatingService.submitRating(this.ratingData).toPromise();
       this.isSubmitting = false;
       this.ratingSessionEnd = true;
     } catch (err) {

--- a/projects/v3/src/app/pages/devtool/devtool.page.html
+++ b/projects/v3/src/app/pages/devtool/devtool.page.html
@@ -5,13 +5,80 @@
 </ion-header>
 
 <ion-content class="ion-padding">
-  <ion-button routerLink="/v3">Go /</ion-button>
-  <ion-button routerLink="/v3/settings">Go Setting</ion-button>
-  <ion-button (click)="refresh()">Refresh JWT</ion-button>
-  <ion-button (click)="pulsecheck()">Pulse check</ion-button>
-  <ion-button (click)="reviewrating()">Rating</ion-button>
-  <ion-button (click)="testAuth()">testAuth</ion-button>
-  <ion-button (click)="testAuth(true)">testAuth-apikey</ion-button>
+  <div class="tools">
+    <h4>Testing tools</h4>
+    <ion-grid>
+      <ion-row>
+        <ion-col size="4" size-sm="3" size-xs="2">
+          <ion-button routerLink="/v3">Go /</ion-button>
+        </ion-col>
+        <ion-col size="4" size-sm="3" size-xs="2">
+          <ion-button routerLink="/v3/settings">Go Setting</ion-button>
+        </ion-col>
+        <ion-col size="4" size-sm="3" size-xs="2">
+          <ion-button (click)="getbadges()">Get Badges</ion-button>
+        </ion-col>
+        <ion-col size="4" size-sm="3" size-xs="2">
+          <ion-button (click)="refresh()">Refresh JWT</ion-button>
+        </ion-col>
+      </ion-row>
+      <ion-row>
+        <ion-col size="4" size-sm="3" size-xs="2">
+          <ion-button (click)="pulsecheck()">Pulse check</ion-button>
+        </ion-col>
+        <ion-col size="4" size-sm="3" size-xs="2">
+          <ion-button (click)="reviewrating()">Rating</ion-button>
+        </ion-col>
+      </ion-row>
+      <ion-row>
+        <ion-col size="4" size-sm="3" size-xs="2">
+          <ion-button (click)="testAuth()">testAuth</ion-button>
+        </ion-col>
+        <ion-col size="4" size-sm="3" size-xs="2">
+          <ion-button (click)="testAuth(true)">testAuth-apikey</ion-button>
+        </ion-col>
+        <ion-col size="4" size-sm="3" size-xs="2">
+          <!-- Optional placeholder -->
+        </ion-col>
+      </ion-row>
+    </ion-grid>
+  </div>
+
+  <ng-container class="device-info" *ngIf="info">
+    <h4>Device Information</h4>
+    <ion-list>
+      <ion-item>
+        <ion-label>User Agent</ion-label>
+        <ion-text>{{ info.userAgent }}</ion-text>
+      </ion-item>
+      <ion-item>
+        <ion-label>Viewport Width</ion-label>
+        <ion-text>{{ info.viewportWidth }}</ion-text>
+      </ion-item>
+      <ion-item>
+        <ion-label>Viewport Height</ion-label>
+        <ion-text>{{ info.viewportHeight }}</ion-text>
+      </ion-item>
+      <ion-item>
+        <ion-label>Screen Width</ion-label>
+        <ion-text>{{ info.screenWidth }}</ion-text>
+      </ion-item>
+      <ion-item>
+        <ion-label>Screen Height</ion-label>
+        <ion-text>{{ info.screenHeight }}</ion-text>
+      </ion-item>
+      <ion-item>
+        <ion-label>Pixel Ratio</ion-label>
+        <ion-text>{{ info.pixelRatio }}</ion-text>
+      </ion-item>
+      <ion-item *ngIf="info.location">
+        <ion-label>Location</ion-label>
+        <ion-text>
+          Latitude: {{ info.location.latitude }}, Longitude: {{ info.location.longitude }}
+        </ion-text>
+      </ion-item>
+    </ion-list>
+  </ng-container>
 
   <h4>Task Unlock indicator</h4>
   <ion-button (click)="triggerAchievement()">MarkAsDone</ion-button>

--- a/projects/v3/src/app/pages/devtool/devtool.page.ts
+++ b/projects/v3/src/app/pages/devtool/devtool.page.ts
@@ -6,6 +6,7 @@ import { NotificationsService } from '@v3/app/services/notifications.service';
 import { BrowserStorageService } from '@v3/app/services/storage.service';
 import { SharedService } from '@v3/app/services/shared.service';
 import { UnlockIndicatorService } from '@v3/app/services/unlock-indicator.service';
+import { Achievement, AchievementService } from '@v3/app/services/achievement.service';
 
 @Component({
   selector: 'app-devtool',
@@ -19,6 +20,19 @@ export class DevtoolPage implements OnInit {
 
   sample: any;
 
+  info: {
+    userAgent: string;
+    viewportWidth: number;
+    viewportHeight: number;
+    screenWidth: number;
+    screenHeight: number;
+    pixelRatio: number;
+    location: {
+      latitude: number;
+      longitude: number;
+    };
+  }
+
   constructor(
     private authService: AuthService,
     private storageService: BrowserStorageService,
@@ -26,6 +40,7 @@ export class DevtoolPage implements OnInit {
     private notificationsService: NotificationsService,
     private experienceService: ExperienceService,
     private sharedService: SharedService,
+    private achievementService: AchievementService,
     private unlockIndicatorService: UnlockIndicatorService
       ) { }
 
@@ -34,6 +49,8 @@ export class DevtoolPage implements OnInit {
     if (this.doneLogin) {
       this.user = this.storageService.get('me');
     }
+
+    this.deviceInfo();
   }
 
   refresh() {
@@ -114,5 +131,45 @@ export class DevtoolPage implements OnInit {
       });
       this.unlockIndicatorService.removeTasks(task.taskId);
     });
+  }
+
+  getbadges() {
+    this.achievementService.getAchievements();
+  }
+
+  deviceInfo() {
+    this.info = {
+      // User Agent
+      userAgent: navigator.userAgent,
+
+      // Viewport Size
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+
+      // Screen Resolution
+      screenWidth: window.screen.width,
+      screenHeight: window.screen.height,
+
+      // Pixel Ratio
+      pixelRatio: window.devicePixelRatio || 1,
+
+      // Geolocation (initialized as null)
+      location: null,
+    };
+
+    // Geolocation (optional)
+    if ('geolocation' in navigator) {
+      navigator.geolocation.getCurrentPosition(
+        (position) => {
+          this.info.location = {
+            latitude: position.coords.latitude,
+            longitude: position.coords.longitude,
+          };
+        },
+        (error) => {
+          console.error('Geolocation error:', error);
+        }
+      );
+    }
   }
 }

--- a/projects/v3/src/app/pages/tabs/tabs.page.html
+++ b/projects/v3/src/app/pages/tabs/tabs.page.html
@@ -1,5 +1,5 @@
 <ion-tabs #tabs (ionTabsDidChange)="setCurrentTab()">
-  <ion-tab-bar slot="bottom" *ngIf="isMobile">
+  <ion-tab-bar slot="bottom" *ngIf="hasLeftSidebar !== true">
     <ion-tab-button class="tab-item" tab="home"
       [ngClass]="{'selected': selectedTab === 'home'}">
       <ion-icon name="home"></ion-icon>

--- a/projects/v3/src/app/pages/tabs/tabs.page.ts
+++ b/projects/v3/src/app/pages/tabs/tabs.page.ts
@@ -1,5 +1,5 @@
-import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
-import { IonTabs, Platform } from '@ionic/angular';
+import { Component, HostListener, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { IonTabs } from '@ionic/angular';
 import { ActivatedRoute } from '@angular/router';
 import { Review, ReviewService } from '@v3/services/review.service';
 import { BrowserStorageService } from '@v3/services/storage.service';
@@ -29,8 +29,9 @@ export class TabsPage implements OnInit, OnDestroy {
     chat: 0,
   };
 
+  isMobile: boolean;
+
   constructor(
-    private platform: Platform,
     private reviewService: ReviewService,
     private storageService: BrowserStorageService,
     private chatService: ChatService,
@@ -38,7 +39,9 @@ export class TabsPage implements OnInit, OnDestroy {
     private notificationsService: NotificationsService,
     private route: ActivatedRoute,
     private activityService: ActivityService,
-  ) {}
+  ) {
+    this.handleResize();
+  }
 
   ngOnInit() {
     this.subscriptions.push(this.reviewService.reviews$.subscribe(res => this.reviews = res));
@@ -97,10 +100,6 @@ export class TabsPage implements OnInit, OnDestroy {
     });
   }
 
-  get isMobile() {
-    return this.utils.isMobile();
-  }
-
   ngOnDestroy(): void {
     this.subscriptions.forEach(sub => {
       if (sub.closed == false) {
@@ -111,5 +110,10 @@ export class TabsPage implements OnInit, OnDestroy {
 
   setCurrentTab() {
     this.selectedTab = this.tabs.getSelected();
+  }
+
+  @HostListener('window:resize', ['$event'])
+  handleResize() {
+    this.isMobile = this.utils.isMobile();
   }
 }

--- a/projects/v3/src/app/pages/tabs/tabs.page.ts
+++ b/projects/v3/src/app/pages/tabs/tabs.page.ts
@@ -29,7 +29,7 @@ export class TabsPage implements OnInit, OnDestroy {
     chat: 0,
   };
 
-  isMobile: boolean;
+  hasLeftSidebar: boolean;
 
   constructor(
     private reviewService: ReviewService,
@@ -43,7 +43,9 @@ export class TabsPage implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.handleResize();
+    this.utils.screenStatus$.subscribe((res) => {
+      this.hasLeftSidebar = res.leftSidebarExpanded;
+    });
     this.subscriptions.push(this.reviewService.reviews$.subscribe(res => this.reviews = res));
     if (!this.storageService.getUser().chatEnabled) { // keep configuration-based value
       this.showMessages = false;
@@ -110,11 +112,5 @@ export class TabsPage implements OnInit, OnDestroy {
 
   setCurrentTab() {
     this.selectedTab = this.tabs.getSelected();
-  }
-
-  @HostListener('window:resize', ['$event'])
-  handleResize() {
-    this.isMobile = this.utils.isMobile();
-    console.log('tab-isMobile::', this.isMobile);
   }
 }

--- a/projects/v3/src/app/pages/tabs/tabs.page.ts
+++ b/projects/v3/src/app/pages/tabs/tabs.page.ts
@@ -40,10 +40,10 @@ export class TabsPage implements OnInit, OnDestroy {
     private route: ActivatedRoute,
     private activityService: ActivityService,
   ) {
-    this.handleResize();
   }
 
   ngOnInit() {
+    this.handleResize();
     this.subscriptions.push(this.reviewService.reviews$.subscribe(res => this.reviews = res));
     if (!this.storageService.getUser().chatEnabled) { // keep configuration-based value
       this.showMessages = false;
@@ -115,5 +115,6 @@ export class TabsPage implements OnInit, OnDestroy {
   @HostListener('window:resize', ['$event'])
   handleResize() {
     this.isMobile = this.utils.isMobile();
+    console.log('tab-isMobile::', this.isMobile);
   }
 }

--- a/projects/v3/src/app/pages/v3/v3.page.html
+++ b/projects/v3/src/app/pages/v3/v3.page.html
@@ -1,6 +1,7 @@
-<ion-split-pane contentId="main-content" [when]="isMobile? 'xl' : '(min-width: 0px)'">
+<ion-split-pane contentId="main-content" [when]="splitpaneEnabled">
   <ion-menu contentId="main-content"
-    [ngClass]="{'collapsed': !isMobile && !openMenu}"
+    swipeGesture="false"
+    [ngClass]="{'collapsed': isMenuOpen === false}"
     [@openClose]="collapsibleMenu"
     (@openClose.done)="direction()">
 
@@ -59,7 +60,7 @@
         </ion-item>
       </ion-list>
 
-      <ion-item *ngIf="!isMobile"
+      <ion-item
         class="footer"
         lines="none"
         detail="false"

--- a/projects/v3/src/app/pages/v3/v3.page.html
+++ b/projects/v3/src/app/pages/v3/v3.page.html
@@ -1,4 +1,4 @@
-<ion-split-pane contentId="main-content" [when]="isMobile? 'lg' : '(min-width: 0px)'">
+<ion-split-pane contentId="main-content" [when]="isMobile? 'xl' : '(min-width: 0px)'">
   <ion-menu contentId="main-content"
     [ngClass]="{'collapsed': !isMobile && !openMenu}"
     [@openClose]="collapsibleMenu"

--- a/projects/v3/src/app/pages/v3/v3.page.html
+++ b/projects/v3/src/app/pages/v3/v3.page.html
@@ -22,7 +22,7 @@
             routerDirection="root"
             detail="false"
             [title]="p.title">
-            <ng-container *ngIf="!isMobile && openMenu === false; else iconOnly">
+            <ng-container *ngIf="isMenuOpen === false; else iconOnly">
               <div class="badge-wrapper icon-container">
                 <ion-icon slot="start" [name]="p.icon" aria-hidden="true" class="indicator"></ion-icon>
                 <ion-badge color="danger" class="hint" *ngIf="p.badges > 0">{{p.badges}}</ion-badge>

--- a/projects/v3/src/app/pages/v3/v3.page.ts
+++ b/projects/v3/src/app/pages/v3/v3.page.ts
@@ -1,5 +1,5 @@
-import { take, takeUntil } from 'rxjs/operators';
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { takeUntil } from 'rxjs/operators';
+import { Component, HostListener, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import { MenuController, ModalController } from '@ionic/angular';
 import { Review, ReviewService } from '@v3/app/services/review.service';
@@ -100,6 +100,11 @@ export class V3Page implements OnInit, OnDestroy {
     this.isMobile = this.utils.isMobile();
   }
 
+  @HostListener('window:resize', ['$event'])
+  ionViewDidEnter() {
+    this.isMobile = this.utils.isMobile();
+  }
+
   ngOnDestroy(): void {
     this.unsubscribe$.next();
     this.unsubscribe$.complete();
@@ -167,7 +172,6 @@ export class V3Page implements OnInit, OnDestroy {
         }
       });
       this.appPages[3].badges = chat?.unreadMessages || 0; // messages tab
-
       this.appPages[1].badges = notifications.filter(noti => noti.type === 'event-reminder').length; // events tab
       this.appPages[2].badges = notifications.filter(noti => noti.type === 'review_submission').length; // reviews tab
     });

--- a/projects/v3/src/app/pages/v3/v3.page.ts
+++ b/projects/v3/src/app/pages/v3/v3.page.ts
@@ -97,12 +97,18 @@ export class V3Page implements OnInit, OnDestroy {
     private readonly homeService: HomeService,
     private readonly unlockIndicatorService: UnlockIndicatorService,
   ) {
-    this.isMobile = this.utils.isMobile();
   }
 
   @HostListener('window:resize', ['$event'])
   ionViewDidEnter() {
     this.isMobile = this.utils.isMobile();
+
+    this.openMenu = false;
+    this.collapsibleMenu = 'closed';
+    // this.collapsibleMenu = this.collapseMenu();
+    this.institutionLogo = this.getInstitutionLogo();
+
+    console.log('v3-isMobile::', this.isMobile);
   }
 
   ngOnDestroy(): void {

--- a/projects/v3/src/app/pages/v3/v3.page.ts
+++ b/projects/v3/src/app/pages/v3/v3.page.ts
@@ -62,7 +62,7 @@ import { UnlockIndicatorService } from '@v3/app/services/unlock-indicator.servic
   ]
 })
 export class V3Page implements OnInit, OnDestroy {
-  openMenu = false; // collapsible submenu
+  isMenuOpen = false; // collapsible submenu
   wait: boolean = false; // loading flag
   reviews: Review[];
   appPages: any[];
@@ -70,9 +70,11 @@ export class V3Page implements OnInit, OnDestroy {
   showEvents: boolean = false;
   showReviews: boolean = false;
   directionIcon: string = this.direction();
-  collapsibleMenu: string = 'closed';
+  collapsibleMenu: 'open' | 'closed' = 'closed';
   institutionLogo: string = this.getInstitutionLogo();
   isMobile: boolean;
+  splitpaneEnabled: boolean | string;
+  isSwipeEnabled: boolean = false;
   institutionName: string;
 
   i18nText = {
@@ -102,13 +104,22 @@ export class V3Page implements OnInit, OnDestroy {
   @HostListener('window:resize', ['$event'])
   ionViewDidEnter() {
     this.isMobile = this.utils.isMobile();
+    let menuEnabled = true;
+    this.isMenuOpen = false;
+    this.splitpaneEnabled = '(min-width: 1024px)';
 
-    this.openMenu = false;
     this.collapsibleMenu = 'closed';
-    // this.collapsibleMenu = this.collapseMenu();
-    this.institutionLogo = this.getInstitutionLogo();
 
-    console.log('v3-isMobile::', this.isMobile);
+    // toggleable-feature: allow swipe in menu when viewport is smaller than 576px
+    // make isSwipeEnabled dynamic to enable
+    if (window.innerWidth < 576) {
+      menuEnabled = false;
+      this.isMenuOpen = true;
+      this.collapsibleMenu = 'open';
+      this.splitpaneEnabled = false;
+    }
+
+    this.menuController.enable(menuEnabled);
   }
 
   ngOnDestroy(): void {
@@ -223,7 +234,7 @@ export class V3Page implements OnInit, OnDestroy {
           }
         });
     }
-    this.openMenu = false;
+    this.isMenuOpen = false;
 
     // initiate subscription v3 page level (required), so the rest independent listener can pickup the same sharedReplay
     this.notificationsService.getTodoItems().pipe(
@@ -279,7 +290,11 @@ export class V3Page implements OnInit, OnDestroy {
   }
 
   getInstitutionLogo(): string {
-    if (this.openMenu !== true) {
+    if (!this.storageService) {
+      return '/assets/logo.svg'; // Default logo or some fallback
+    }
+
+    if (this.isMenuOpen !== true) {
       return this.storageService.getUser().squareLogo || '';
     }
 
@@ -287,24 +302,20 @@ export class V3Page implements OnInit, OnDestroy {
   }
 
   toggleMenu() {
-    this.openMenu = !this.openMenu;
+    this.isMenuOpen = !this.isMenuOpen;
     this.collapsibleMenu = this.collapseMenu();
     this.institutionLogo = this.getInstitutionLogo();
   }
 
   // only desktop version require collapsed menu
   // get collapsibleMenu() {
-  collapseMenu(): string {
-    if (this.isMobile) {
-      return 'open';
-    }
-
-    return (this.openMenu ? 'open' : 'closed');
+  collapseMenu(): 'open' | 'closed' {
+    return (this.isMenuOpen ? 'open' : 'closed');
   }
 
   // rotation animation logic
   direction(): string {
-    this.directionIcon = this.openMenu ? 'keyboard_double_arrow_left' : 'keyboard_double_arrow_right';
+    this.directionIcon = this.isMenuOpen ? 'keyboard_double_arrow_left' : 'keyboard_double_arrow_right';
     return this.directionIcon;
   }
 

--- a/projects/v3/src/app/pages/v3/v3.page.ts
+++ b/projects/v3/src/app/pages/v3/v3.page.ts
@@ -72,7 +72,6 @@ export class V3Page implements OnInit, OnDestroy {
   directionIcon: string = this.direction();
   collapsibleMenu: 'open' | 'closed' = 'closed';
   institutionLogo: string = this.getInstitutionLogo();
-  isMobile: boolean;
   splitpaneEnabled: boolean | string;
   isSwipeEnabled: boolean = false;
   institutionName: string;
@@ -82,7 +81,6 @@ export class V3Page implements OnInit, OnDestroy {
     'myExperience': $localize`My Experiences`
   };
   hasUnlockedTasks: boolean;
-
   unsubscribe$ = new Subject();
 
   constructor(
@@ -103,10 +101,9 @@ export class V3Page implements OnInit, OnDestroy {
 
   @HostListener('window:resize', ['$event'])
   ionViewDidEnter() {
-    this.isMobile = this.utils.isMobile();
     let menuEnabled = true;
+    let splitpaneEnabled = false;
     this.isMenuOpen = false;
-    this.splitpaneEnabled = '(min-width: 1024px)';
 
     this.collapsibleMenu = 'closed';
 
@@ -116,9 +113,12 @@ export class V3Page implements OnInit, OnDestroy {
       menuEnabled = false;
       this.isMenuOpen = true;
       this.collapsibleMenu = 'open';
-      this.splitpaneEnabled = false;
+    } else if (window.innerWidth >= 1024) {
+      splitpaneEnabled = true;
     }
 
+    this.splitpaneEnabled = splitpaneEnabled;
+    this.utils.viewport('leftSidebarExpanded', this.splitpaneEnabled);
     this.menuController.enable(menuEnabled);
   }
 
@@ -164,9 +164,6 @@ export class V3Page implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    if (this.isMobile) {
-      this.menuController.enable(false);
-    }
     this._initMenuItems();
 
     this.reviewService.reviews$

--- a/projects/v3/src/app/services/utils.service.ts
+++ b/projects/v3/src/app/services/utils.service.ts
@@ -47,10 +47,35 @@ export class UtilsService {
   }
 
   /**
+   * get orientation of the device by comparing window height and width
+   *
+   * @return  {boolean} true if portrait, false if landscape
+   */
+  isPortrait(): boolean {
+    return window.innerHeight > window.innerWidth ? true : false;
+  }
+
+  /**
+   * Treat viewport size start from large tablet as desktop
+   * grouping device type into 2 group (mobile/desktop)
    * @name isMobile
-   * @description grouping device type into 2 group (mobile/desktop) and return true if mobile, otherwise return false
+   * @return {boolean} true if mobile, false if desktop
    */
   isMobile(): boolean {
+    if (this.platform.is('desktop')) {
+      return false;
+    }
+
+    if (this.platform.is('tablet')) {
+      if (window.innerWidth < 1024) {
+        return true;
+      }
+
+      // for larger tablet (iPad Pro & samsung 10)
+      // considered as desktop (1024px = logical viewport)
+      return false;
+    }
+
     return this.platform.is('mobile');
   }
 

--- a/projects/v3/src/app/services/utils.service.ts
+++ b/projects/v3/src/app/services/utils.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Inject } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
-import { Observable, Subject } from 'rxjs';
+import { Observable, Subject, BehaviorSubject } from 'rxjs';
 import { map, filter } from 'rxjs/operators';
 import { ModalController, Platform } from '@ionic/angular';
 import * as _ from 'lodash';
@@ -22,15 +22,16 @@ declare var window: any;
   providedIn: 'root'
 })
 export class UtilsService {
+  private _screenStatus$ = new BehaviorSubject<{
+    leftSidebarExpanded: boolean;
+  }>({
+    leftSidebarExpanded: false,
+  });
+  public screenStatus$ = this._screenStatus$.asObservable();
+
   private lodash;
   // this Subject is used to broadcast an event to the app
   protected _eventsSubject = new Subject<{ key: string, value: any }>();
-  // -- Not in used anymore, leave them commented in case we need later --
-  // // this Subject is used in project.service to cache the project data
-  // public projectSubject = new BehaviorSubject(null);
-  // // this Subject is used in activity.service to cache the activity data
-  // // it stores key => Subject pairs of all activities
-  // public activitySubjects = {};
 
   constructor(
     @Inject(DOCUMENT) private document: Document,
@@ -53,6 +54,15 @@ export class UtilsService {
    */
   isPortrait(): boolean {
     return window.innerHeight > window.innerWidth ? true : false;
+  }
+
+  // set screen status (left sidebar expanded, etc)
+  viewport(name: 'leftSidebarExpanded', value) {
+    const values = this._screenStatus$.getValue();
+    this._screenStatus$.next({
+      ...values,
+      ...{ [name]: value }
+    });
   }
 
   /**


### PR DESCRIPTION
changes

- added support for large tablet logical viewport (1024px)
- logical viewport now grouped into 2,
- normal tablet like iPad mini or samsung tab s9,
- large tablet like > 10in (samsung tab 10s or ipad air/pro 10 or 13in)
[[CORE-7653](https://intersective.atlassian.net/browse/CORE-7653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)](https://intersective.atlassian.net/browse/CORE-7653)
- replaced usage of isMobile on both tab and side menu with menu expanded status (so only one exist concurrently)

[CORE-7653]: https://intersective.atlassian.net/browse/CORE-7653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ