### PR TITLE
[CORE-7903] 2.4.y/review submission with file

### DIFF
--- a/projects/v3/src/app/components/assessment/assessment.component.ts
+++ b/projects/v3/src/app/components/assessment/assessment.component.ts
@@ -567,11 +567,16 @@ Best regards`;
       // ]
       this.utils.each(this.questionsForm.value, (answer, key) => {
         questionId = +key.replace('q-', '');
-        answers.push({
+        const save: { questionId: number; answer: any; comment: any; file?: any } = {
           questionId,
           answer: answer?.answer,
           comment: answer?.comment,
-        });
+        };
+        if (answer.file) {
+          save.file = answer.file;
+        }
+
+        answers.push(save);
       });
     }
 

--- a/projects/v3/src/app/components/file-display/file-display.component.html
+++ b/projects/v3/src/app/components/file-display/file-display.component.html
@@ -37,7 +37,7 @@
 
 <ng-template #fileDetails>
   <app-list-item
-    [title]="file.name"
+    [title]="file.name || file.filename"
     leadingIcon="document"
     [lines]="lines"
     [endingActionBtnIcons]="endingActionBtnIcons"

--- a/projects/v3/src/app/components/file-display/file-display.component.ts
+++ b/projects/v3/src/app/components/file-display/file-display.component.ts
@@ -11,6 +11,13 @@ import { FileInput, TusFileResponse } from '../types/assessment';
 import { FilePopupComponent } from '../file-popup/file-popup.component';
 import { ModalController } from '@ionic/angular';
 
+// @TODO: make compatible with FileStack format (remove when no longer needed)
+interface FileStackCompatible extends TusFileResponse {
+  filename: string;
+  mimetype: string;
+  url: string;
+}
+
 @Component({
   selector: 'app-file-display',
   templateUrl: 'file-display.component.html',
@@ -18,7 +25,7 @@ import { ModalController } from '@ionic/angular';
 })
 export class FileDisplayComponent {
   @Input() fileType: string = 'any';
-  @Input() file?: TusFileResponse;
+  @Input() file?: FileStackCompatible;
   @Input() isFileComponent: boolean = false; // flag parent component is FileComponent
   @ViewChild('videoEle') videoEle?: ElementRef = new ElementRef(null);
   @Output() removeFile: EventEmitter<any> = new EventEmitter<any>();

--- a/projects/v3/src/app/components/file-upload/file-upload.component.ts
+++ b/projects/v3/src/app/components/file-upload/file-upload.component.ts
@@ -216,7 +216,7 @@ export class FileUploadComponent implements OnInit, OnDestroy {
         reviewId: this.reviewId,
         submissionId: this.submissionId,
         questionId: this.question.id,
-        file: this.innerValue.answer,
+        file: this.innerValue.file,
         comment: this.innerValue.comment,
       };
     }
@@ -240,15 +240,13 @@ export class FileUploadComponent implements OnInit, OnDestroy {
       if (!this.innerValue) {
         this.innerValue = {
           answer: {},
-          comment: ''
+          comment: '',
+          file: {},
         };
       }
-      if (type === 'comment') {
-        // just pass the value for comment since comment is always just text
-        this.innerValue.comment = value;
-      } else {
-        this.innerValue.answer = this.fileRequestFormat();
-      }
+
+      this.innerValue.file = this.fileRequestFormat();
+      this.innerValue[type] = value;
     } else { // for assessment
       this.innerValue = this.fileRequestFormat();
     }
@@ -286,6 +284,7 @@ export class FileUploadComponent implements OnInit, OnDestroy {
       this.innerValue.comment = this.review.comment;
       this.comment = this.review.comment;
       this.innerValue.answer = this.review.answer;
+      this.innerValue.file = this.review.file;
     }
     if ((this.submissionStatus === 'in progress') && (this.doAssessment)) {
       this.innerValue = this.submission.answer;


### PR DESCRIPTION
change:
- reviewSubmission: file is now an part of the value in the json object `{ answer, file, comment }`
- display `filename` from previous filestack object (even no longer supporting it) - graceful fallback