### PR TITLE
Remove admin WYSIWYG blockquote styling [CORE-7942]

### DIFF
--- a/projects/v3/src/app/components/description/description.component.scss
+++ b/projects/v3/src/app/components/description/description.component.scss
@@ -123,9 +123,10 @@ ion-button {
   line-height: 1.2;
 }
 
-blockquote {
-  margin: 0 0 1rem;
-}
+// removed for showing more space between blockquotes and other elements for assessment descriptions editor (different editor than admin wysiwyg) [CORE-7942]
+// blockquote {
+//   margin: 0 0 1rem;
+// }
 
 dl,
 ol,


### PR DESCRIPTION
https://intersective.atlassian.net/browse/CORE-7942
Eliminate blockquote styling in the admin WYSIWYG to create more space between blockquotes and other elements in the assessment descriptions editor.