### PR TITLE
hide fab button temporarily in activity-desktop page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ www/*
 .env
 projects/v3/src/environments/environment.ts
 projects/v3/src/environments/environment.prod.ts
+output/

--- a/projects/v3/src/app/pages/activity-desktop/activity-desktop.page.html
+++ b/projects/v3/src/app/pages/activity-desktop/activity-desktop.page.html
@@ -42,7 +42,8 @@
     </ion-row>
   </ion-grid>
 
-  <ng-container *ngIf="currentTask?.type === 'Assessment'">
+  <ng-container *ngIf="currentTask?.type === 'Assessment' && false">
+    <!-- temporary hide fab button - assessment question navigator -->
     <span class="tooltip-container"
       [ngStyle]="tooltipStyle"
       *ngIf="tooltipVisible">


### PR DESCRIPTION
This pull request introduces a temporary change to the `activity-desktop.page.html` file to hide the floating action button (FAB) for the assessment question navigator. This is achieved by modifying the conditional rendering logic.

UI behavior adjustment:

* Temporarily disables the FAB button for the assessment question navigator by updating the `*ngIf` condition to always evaluate as false in the `ng-container` element. (`projects/v3/src/app/pages/activity-desktop/activity-desktop.page.html`)