### PR TITLE
[CORE-7691] fix ffmpeg asset URLs to use document.baseURI instead of window.location.origin

### DIFF
--- a/projects/v3/src/app/services/ffmpeg.service.ts
+++ b/projects/v3/src/app/services/ffmpeg.service.ts
@@ -105,9 +105,9 @@ export class FfmpegService {
     });
 
     await this.ffmpeg.load({
-      coreURL: new URL('assets/ffmpeg/ffmpeg-core.js', window.location.origin).toString(),
-      wasmURL: new URL('assets/ffmpeg/ffmpeg-core.wasm', window.location.origin).toString(),
-      classWorkerURL: new URL('assets/ffmpeg/worker.js', window.location.origin).toString(),
+      coreURL: new URL('assets/ffmpeg/ffmpeg-core.js', document.baseURI).toString(),
+      wasmURL: new URL('assets/ffmpeg/ffmpeg-core.wasm', document.baseURI).toString(),
+      classWorkerURL: new URL('assets/ffmpeg/worker.js', document.baseURI).toString(),
     });
 
     this.isLoaded = true;


### PR DESCRIPTION
window.location.origin omits the app base-href (/en-US/) so asset requests hit the SPA fallback and return index.html instead of the actual files. document.baseURI already includes the base-href, resolving to the correct path.

**Story/Ticket Reference ID from JIRA:**
`Add link here`

**Additional Comments:**
`Add here`

**Checklist:**

- [x] Unit test completed?: (Y/N)
- [x] Docs folder up to date?: (Y/N)
- [x] Add if anything missed: (Y/N)

All checklists are okay.

This PR looks great - it's ready to merge! Please review and let's ship it. :)
