### PR TITLE
fix(local): satisfy strictTemplates for keyboard and chat handlers

### DIFF
--- a/projects/v3/src/app/components/review-list/review-list.component.ts
+++ b/projects/v3/src/app/components/review-list/review-list.component.ts
@@ -62,17 +62,19 @@ export class ReviewListComponent implements OnInit, OnChanges, AfterViewInit {
   }
 
   // go to the review
-  goto(review: Review, keyboardEvent?: KeyboardEvent) {
-    if (keyboardEvent && (keyboardEvent?.code === 'Space' || keyboardEvent?.code === 'Enter')) {
-      keyboardEvent.preventDefault();
-    } else if (keyboardEvent) {
-      return;
+  goto(review: Review, keyboardEvent?: Event) {
+    if (keyboardEvent instanceof KeyboardEvent) {
+      if (keyboardEvent.code === 'Space' || keyboardEvent.code === 'Enter') {
+        keyboardEvent.preventDefault();
+      } else {
+        return;
+      }
     }
 
     this.navigate.emit(review);
   }
 
-  switchStatus(event: CustomEvent<SegmentChangeEventDetail>) {
+  switchStatus(event?: CustomEvent<SegmentChangeEventDetail>) {
     if (!event) {
       return;
     }

--- a/projects/v3/src/app/pages/badges-certificates/badges-certificates.page.ts
+++ b/projects/v3/src/app/pages/badges-certificates/badges-certificates.page.ts
@@ -93,15 +93,11 @@ export class BadgesCertificatesPage implements OnInit, OnDestroy {
     this._updatePage();
   }
 
-  async openBadgeDetail(achievement: Achievement, keyboardEvent?: KeyboardEvent) {
-    if (
-      keyboardEvent &&
-      keyboardEvent.key !== 'Enter' &&
-      keyboardEvent.key !== ' '
-    ) {
-      return;
-    }
-    if (keyboardEvent) {
+  async openBadgeDetail(achievement: Achievement, keyboardEvent?: Event) {
+    if (keyboardEvent instanceof KeyboardEvent) {
+      if (keyboardEvent.key !== 'Enter' && keyboardEvent.key !== ' ') {
+        return;
+      }
       keyboardEvent.preventDefault();
     }
     const modal = await this.modalController.create({

--- a/projects/v3/src/app/pages/chat/chat-room/chat-room.component.ts
+++ b/projects/v3/src/app/pages/chat/chat-room/chat-room.component.ts
@@ -1024,14 +1024,13 @@ export class ChatRoomComponent implements OnInit, OnDestroy, AfterViewInit {
     return result;
   }
 
-  async preview(file, keyboardEvent?: KeyboardEvent) {
-    if (
-      keyboardEvent &&
-      (keyboardEvent?.code === "Space" || keyboardEvent?.code === "Enter")
-    ) {
-      keyboardEvent.preventDefault();
-    } else if (keyboardEvent) {
-      return;
+  async preview(file, keyboardEvent?: Event) {
+    if (keyboardEvent instanceof KeyboardEvent) {
+      if (keyboardEvent.code === "Space" || keyboardEvent.code === "Enter") {
+        keyboardEvent.preventDefault();
+      } else {
+        return;
+      }
     }
 
     const modal = await this.modalController.create({
@@ -1169,7 +1168,14 @@ export class ChatRoomComponent implements OnInit, OnDestroy, AfterViewInit {
   /**
    * open edit modal for a sent message.
    */
-  async openEditMessagePopup(index: number) {
+  async openEditMessagePopup(messageOrIndex: Message | number) {
+    const index =
+      typeof messageOrIndex === 'number'
+        ? messageOrIndex
+        : this.messageList.findIndex((message) => message.uuid === messageOrIndex.uuid);
+    if (index < 0) {
+      return;
+    }
     const modal = await this.modalController.create({
       component: EditMessagePopupComponent,
       cssClass: 'chat-edit-message-popup',


### PR DESCRIPTION
## Summary

- Fix Angular `strictTemplates` compile errors blocking `ng serve` in the local Docker stack.
- Use `Event` with `instanceof KeyboardEvent` narrowing in keyboard-accessible handlers (`review-list`, `badges-certificates`, `chat-room` preview).
- Make `switchStatus` event optional in `review-list` to match the template binding.
- Allow `openEditMessagePopup` to accept a `Message` object (template) or numeric index (existing tests), resolving the `Message` vs `number` type error.

## Test plan

- [ ] `npx ng build v3 -c development`
- [ ] `docker compose` / TUI: `practera-app` container reaches watch mode on port 4200
- [ ] Smoke: badges list keyboard activation, chat edit message popup opens


Made with [Cursor](https://cursor.com)