### PR TITLE
[CORE-8270] 2.4.y/branding-brief-style

### DIFF
--- a/docs/features/project-brief.md
+++ b/docs/features/project-brief.md
@@ -34,10 +34,11 @@ showProjectBrief() → opens ProjectBriefModalComponent
 - `project-brief-modal.component.scss` - Component-specific styles
 - `project-brief-modal.component.spec.ts` - Unit tests
 
-**Input:**
+**Modal property:**
 ```typescript
-@Input() projectBrief: ProjectBrief = {};
+projectBrief: ProjectBrief = {};
 ```
+Ionic sets this public property through `componentProps` when the modal is created.
 
 **Interface:**
 ```typescript
@@ -61,6 +62,10 @@ interface ProjectBrief {
 - Technical Skills (as chips)
 - Professional Skills (as chips)
 - Deliverables
+
+**Color treatment:**
+- Modal section header icons and chips use the primary brand color.
+- Do not use the secondary brand color for Technical Skills accents; customer secondary colors can be too light to remain visible on the light modal background.
 
 **Empty Field Handling:**
 - All sections show "None specified" when the field is empty or undefined
@@ -181,7 +186,7 @@ Button placement - next to experience name:
 - Keyboard navigation with `(keydown.enter)` and `(keydown.space)` handlers
 - Modal has proper semantic structure with `<main>`, `<section>`, and heading hierarchy
 - Close button includes `aria-label="Close project brief"`
-- Ion-chips for industry/skills are visually distinct with color coding
+- Ion-chips for industry/skills use the primary brand color so labels and outlines remain visible when secondary branding is faint
 
 ## Sample Data
 
@@ -219,6 +224,7 @@ After parsing:
 - Template renders title when provided
 - Template shows "None specified" for empty fields
 - Template renders chips for industry and skills
+- Template keeps section accents on the primary brand color
 
 **HomePage tests (additions needed):**
 - Button visible when `projectBrief` is set

--- a/projects/v3/src/app/components/project-brief-modal/project-brief-modal.component.html
+++ b/projects/v3/src/app/components/project-brief-modal/project-brief-modal.component.html
@@ -59,13 +59,13 @@
 
     <ion-accordion value="technical-skills">
       <ion-item slot="header" color="light">
-        <ion-icon name="code-slash-outline" slot="start" color="secondary" aria-hidden="true"></ion-icon>
+        <ion-icon name="code-slash-outline" slot="start" color="primary" aria-hidden="true"></ion-icon>
         <ion-label class="accordion-header" i18n>Technical Skills</ion-label>
       </ion-item>
       <div slot="content" class="accordion-content">
         <div class="chip-container" *ngIf="hasItems(projectBrief?.technicalSkills); else noTechnicalSkills">
           <ion-chip *ngFor="let skill of projectBrief.technicalSkills"
-            color="secondary"
+            color="primary"
             outline="true">
             <ion-label>{{ skill }}</ion-label>
           </ion-chip>
@@ -78,13 +78,13 @@
 
     <ion-accordion value="professional-skills">
       <ion-item slot="header" color="light">
-        <ion-icon name="people-outline" slot="start" color="tertiary" aria-hidden="true"></ion-icon>
+        <ion-icon name="people-outline" slot="start" color="primary" aria-hidden="true"></ion-icon>
         <ion-label class="accordion-header" i18n>Professional Skills</ion-label>
       </ion-item>
       <div slot="content" class="accordion-content">
         <div class="chip-container" *ngIf="hasItems(projectBrief?.professionalSkills); else noProfessionalSkills">
           <ion-chip *ngFor="let skill of projectBrief.professionalSkills"
-            color="tertiary"
+            color="primary"
             outline="true">
             <ion-label>{{ skill }}</ion-label>
           </ion-chip>
@@ -97,7 +97,7 @@
 
     <ion-accordion value="deliverables">
       <ion-item slot="header" color="light">
-        <ion-icon name="checkbox-outline" slot="start" color="success" aria-hidden="true"></ion-icon>
+        <ion-icon name="checkbox-outline" slot="start" color="primary" aria-hidden="true"></ion-icon>
         <ion-label class="accordion-header" i18n>Deliverables</ion-label>
       </ion-item>
       <div slot="content" class="accordion-content">

--- a/projects/v3/src/app/components/project-brief-modal/project-brief-modal.component.spec.ts
+++ b/projects/v3/src/app/components/project-brief-modal/project-brief-modal.component.spec.ts
@@ -117,5 +117,30 @@ describe('ProjectBriefModalComponent', () => {
       const chips = fixture.nativeElement.querySelectorAll('ion-chip');
       expect(chips.length).toBe(4);
     });
+
+    it('should use the primary brand color for section accents', () => {
+      component.projectBrief = {
+        industry: ['Health'],
+        technicalSkills: ['Python'],
+        professionalSkills: ['Leadership'],
+        deliverables: 'Prototype'
+      };
+      fixture.detectChanges();
+
+      const accentSelectors = [
+        'ion-icon[name="document-text-outline"]',
+        'ion-icon[name="business-outline"]',
+        'ion-icon[name="code-slash-outline"]',
+        'ion-icon[name="people-outline"]',
+        'ion-icon[name="checkbox-outline"]',
+        'ion-chip'
+      ];
+
+      accentSelectors.forEach((selector) => {
+        fixture.nativeElement.querySelectorAll(selector).forEach((element: Element) => {
+          expect(element.getAttribute('color')).toBe('primary');
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
Adjust the project brief modal to consistently use the primary brand color for section headers and chips, enhancing visibility and coherence in design. This change improves the overall user experience by ensuring that all relevant elements are visually aligned with the brand's identity.

