### PR TITLE
[CORE-6152] 2.4.y/accessWidget-blockage-trunk

### DIFF
--- a/docs/accessibility/WCAG_CHECKLIST.md
+++ b/docs/accessibility/WCAG_CHECKLIST.md
@@ -123,6 +123,9 @@ This checklist verifies compliance with WCAG 2.2 Level AA standards for the V3 I
 - [x] **COMPLETED**: Added CSS to prevent focus obscuring (scroll-margin: 4px on focus-visible elements)
 - [x] Sticky headers/footers have proper z-index (ion-header and ion-footer set to z-index: 1000)
 - [x] Modals/overlays configured with backdrop opacity (ion-modal has --backdrop-opacity: 0.4)
+- [x] **COMPLETED**: Replaced accessWidget's production floating trigger with a keyboard-accessible custom trigger in the personalised header
+- [x] **COMPLETED**: Reserved production-only inline space in the chat action row so a vendor-overridden floating trigger cannot obscure Attach or Send
+- [ ] **RETEST ON DEPLOYED HOST**: Verify the custom trigger opens accessWidget and the chat controls remain unobscured at desktop, tablet, and mobile viewports
 
 #### 2.4.13 Focus Appearance (Minimum) (Level AA) - NEW in 2.2
 - [x] Focus indicators have at least 2px outline (implemented in global.scss)
@@ -394,7 +397,7 @@ This checklist verifies compliance with WCAG 2.2 Level AA standards for the V3 I
 7. Test with keyboard: Tab to element, tooltip should appear; ESC should dismiss it
 
 #### 5. Focus Not Obscured (WCAG 2.4.11)
-**Fixed in:** `global.scss`
+**Fixed in:** `global.scss`, `styles.scss`, `personalised-header.component.html`, and `index.html`
 
 **Retest Instructions:**
 1. Navigate to any page with sticky header/footer
@@ -404,6 +407,11 @@ This checklist verifies compliance with WCAG 2.2 Level AA standards for the V3 I
 5. Open DevTools and check computed styles on focused element:
    - `scroll-margin: 4px` should be present
    - `z-index` on headers/footers should be 1000
+6. On a deployed non-local host, Tab to the header button labelled "Open accessibility options"
+7. **VERIFY**: Enter and Space open accessWidget and the button remains visible with support, notification, and profile controls
+8. Navigate to Messages and select a writable chat room
+9. **VERIFY**: Attach and Send remain visible and clickable at 2048x1048, 1366x768, 1024x768, and 390x844
+10. **VERIFY**: If accessiBe overrides `hideTrigger`, the remaining floating trigger does not obscure the chat action row
 
 #### 6. Text Spacing Support (WCAG 1.4.12)
 **Fixed in:** `global.scss`
@@ -494,4 +502,3 @@ This checklist verifies compliance with WCAG 2.2 Level AA standards for the V3 I
 - Assessment component has loading states with proper ARIA
 - Error messages use role="alert" and aria-live="assertive"
 - Status messages use role="status" and aria-live="polite"
-

--- a/projects/v3/src/app/personalised-header/personalised-header.component.html
+++ b/projects/v3/src/app/personalised-header/personalised-header.component.html
@@ -25,6 +25,17 @@
     </ion-button>
   </ng-template>
 
+  <ion-button class="accessibility-btn"
+    data-acsb-custom-trigger="true"
+    aria-label="Open accessibility options" i18n-aria-label>
+    <ion-icon
+      name="accessibility-outline"
+      color="primary"
+      slot="icon-only"
+      aria-hidden="true"
+    ></ion-icon>
+  </ion-button>
+
   <ion-button *ngIf="!isExpPage"
     (click)="notifications()"
     (keydown.enter)="notifications()"

--- a/projects/v3/src/app/personalised-header/personalised-header.component.scss
+++ b/projects/v3/src/app/personalised-header/personalised-header.component.scss
@@ -20,6 +20,7 @@ ion-avatar {
       opacity: 0.5;
     }
   }
+  .accessibility-btn,
   .notify-btn {
     height: 34px;
     width: 34px;
@@ -28,7 +29,9 @@ ion-avatar {
     --padding-end: 1px;
     --padding-bottom: 1px;
     --padding-start: 1px;
+  }
 
+  .notify-btn {
     .hint {
       background-color: red;
       position: absolute;

--- a/projects/v3/src/app/personalised-header/personalised-header.component.spec.ts
+++ b/projects/v3/src/app/personalised-header/personalised-header.component.spec.ts
@@ -75,4 +75,17 @@ describe('PersonalisedHeaderComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should expose the accessWidget custom trigger before notifications', () => {
+    const accessibilityButton: HTMLElement = fixture.nativeElement.querySelector('.accessibility-btn');
+    const notificationButton: HTMLElement = fixture.nativeElement.querySelector('.notify-btn');
+    const icon: HTMLElement = accessibilityButton.querySelector('ion-icon');
+
+    expect(accessibilityButton).toBeTruthy();
+    expect(accessibilityButton.getAttribute('aria-label')).toBe('Open accessibility options');
+    expect(accessibilityButton.getAttribute('data-acsb-custom-trigger')).toBe('true');
+    expect(icon.getAttribute('name')).toBe('accessibility-outline');
+    expect(accessibilityButton.compareDocumentPosition(notificationButton) & Node.DOCUMENT_POSITION_FOLLOWING)
+      .toBeTruthy();
+  });
 });

--- a/projects/v3/src/index.html
+++ b/projects/v3/src/index.html
@@ -19,6 +19,57 @@
 </head>
 <body>
   <app-root></app-root>
-  <script> if (!location.host.startsWith("localhost:") && !location.host.startsWith("127.0.0.1:")) { (function(){ var s = document.createElement('script'); var h = document.querySelector('head') || document.body; s.src = 'https://acsbapp.com/apps/app/dist/js/app.js'; s.async = true; s.onload = function(){ acsbJS.init({ statementLink : '', footerHtml : '', hideMobile : false, hideTrigger : false, disableBgProcess : false, language : 'en', position : 'left', leadColor : '#4d4d4d', triggerColor : '#4d4d4d', triggerRadius : '50%', triggerPositionX : 'left', triggerPositionY : 'bottom', triggerIcon : 'people', triggerSize : 'medium', triggerOffsetX : 15, triggerOffsetY : 40, mobile : { triggerSize : 'small', triggerPositionX : 'right', triggerPositionY : 'bottom', triggerOffsetX : 10, triggerOffsetY : 10, triggerRadius : '50%' } }); }; h.appendChild(s); })(); } </script>
+  <script>
+    if (!location.host.startsWith('localhost:') && !location.host.startsWith('127.0.0.1:')) {
+      (function () {
+        var widgetEnabledClass = 'accessibility-widget-enabled';
+        var script = document.createElement('script');
+        var scriptContainer = document.querySelector('head') || document.body;
+
+        document.body.classList.add(widgetEnabledClass);
+
+        script.src = 'https://acsbapp.com/apps/app/dist/js/app.js';
+        script.async = true;
+        script.onerror = function () {
+          document.body.classList.remove(widgetEnabledClass);
+        };
+        script.onload = function () {
+          if (!window.acsbJS || typeof window.acsbJS.init !== 'function') {
+            document.body.classList.remove(widgetEnabledClass);
+            return;
+          }
+
+          window.acsbJS.init({
+            statementLink: '',
+            footerHtml: '',
+            hideMobile: false,
+            hideTrigger: true,
+            disableBgProcess: false,
+            language: 'en',
+            position: 'left',
+            leadColor: '#4d4d4d',
+            triggerColor: '#4d4d4d',
+            triggerRadius: '50%',
+            triggerPositionX: 'left',
+            triggerPositionY: 'bottom',
+            triggerIcon: 'people',
+            triggerSize: 'medium',
+            triggerOffsetX: 15,
+            triggerOffsetY: 40,
+            mobile: {
+              triggerSize: 'small',
+              triggerPositionX: 'right',
+              triggerPositionY: 'bottom',
+              triggerOffsetX: 10,
+              triggerOffsetY: 10,
+              triggerRadius: '50%'
+            }
+          });
+        };
+
+        scriptContainer.appendChild(script);
+      })();
+    }
+  </script>
 </body>
 </html>

--- a/projects/v3/src/styles.scss
+++ b/projects/v3/src/styles.scss
@@ -569,3 +569,20 @@ quill-editor .ql-toolbar.ql-snow {
     margin-right: 8px !important;
   }
 }
+
+// accessWidget is loaded only on non-local hosts. Keep its custom trigger out
+// of the local UI and reserve enough room for the vendor trigger if a remote
+// accessiBe configuration overrides hideTrigger.
+body:not(.accessibility-widget-enabled) app-personalised-header .accessibility-btn {
+  display: none;
+}
+
+body.accessibility-widget-enabled app-chat-room ion-row.action-buttons {
+  padding-inline-end: 64px;
+}
+
+@media (min-width: 768px) {
+  body.accessibility-widget-enabled app-chat-room ion-row.action-buttons {
+    padding-inline-end: 88px;
+  }
+}


### PR DESCRIPTION
`CORE-6152`



**Additional Comments:**

Replace the accessWidget's production floating trigger with a keyboard-accessible custom trigger in the personalised header. Ensure the chat action row remains unobscured by reserving space for vendor-overridden triggers.



**Checklist:**



- [x] Unit test completed?: (Y)

- [x] Docs folder up to date?: (Y)

- [x] Add if anything missed: (N)



All checklists are okay.



This PR looks great - it's ready to merge! Please review and let's ship it. :)

